### PR TITLE
Add slider ranges for nonlooping green segments

### DIFF
--- a/stages/chain_state.cc
+++ b/stages/chain_state.cc
@@ -626,7 +626,7 @@ void ChainState::HandleRequest(Settings* settings) {
       }
       s->segment_configuration[i] &= ~0b00000100; // Reset loop bits
       s->segment_configuration[i] |= new_loop_bit; // Set new loop bit
-      if (new_loop_bit != loop_bit) {
+      if (new_loop_bit != loop_bit && request_.argument[0] == request_.argument[3]) {
         s->segment_configuration[i] &= ~0xff00; // Reset LFO range
         dirty = true;
       }

--- a/stages/chain_state.h
+++ b/stages/chain_state.h
@@ -197,7 +197,7 @@ class ChainState {
                 0.98f,
                 0.0f,
                 1.0f);
-          // If in fast range, constrain slider values to first 2/3 of the pot's travel
+          // If in fast range, set slider range to 1 millisecond to ~2.2 seconds
           case 0x0100:
             return block.cv_slider_alt(
                 i,

--- a/stages/chain_state.h
+++ b/stages/chain_state.h
@@ -189,7 +189,7 @@ class ChainState {
           return block.cv_slider[i];
         }
         switch (seg_config & 0x0300) {
-          // If in slow range, set slider min to 16 seconds and max to 800 seconds
+          // If in slow range, set slider min to 16 seconds and max to ~13.4 minutes
           case 0x0200:
             return block.cv_slider_alt(
                 i,

--- a/stages/chain_state.h
+++ b/stages/chain_state.h
@@ -185,36 +185,32 @@ class ChainState {
     // and a `switch` with flipped cases.
     switch (seg_config & 0x03) {
       case segment::TYPE_RAMP:
-      {
         if (loop_status_[i] == LOOP_STATUS_SELF) {
           return block.cv_slider[i];
         }
-        const int range = seg_config & 0x0300;
-        if (range == 0x0200) {
-          // If in slow range, set slider min to 16 seconds and max to 1125 seconds
-          return block.cv_slider_alt(
-              i,
-              1.0f,
-              1.0f,
-              0.0f,
-              1.0f);
-        } else if (range == 0x0100) {
+        switch (seg_config & 0x0300) {
+          // If in slow range, set slider min to 16 seconds and max to 800 seconds
+          case 0x0200:
+            return block.cv_slider_alt(
+                i,
+                1.0f,
+                0.98f,
+                0.0f,
+                1.0f);
           // If in fast range, constrain slider values to first 2/3 of the pot's travel
-          return block.cv_slider_alt(
-              i,
-              0.0f,
-              0.6667f,
-              0.0f,
-              1.0f);
-        } else {
+          case 0x0100:
+            return block.cv_slider_alt(
+                i,
+                0.0f,
+                0.6667f,
+                0.0f,
+                1.0f);
           // If in default range, retain slider range of 1 millisecond to 16 seconds
-          return block.cv_slider[i];
-        }
+          default:
+            return block.cv_slider[i];
       }
       case segment::TYPE_TURING:
-      {
         return block.cv_slider[i];
-      }
       default:
         {
           uint8_t scale = seg_config >> 12 & 0x03;

--- a/stages/chain_state.h
+++ b/stages/chain_state.h
@@ -185,8 +185,36 @@ class ChainState {
     // and a `switch` with flipped cases.
     switch (seg_config & 0x03) {
       case segment::TYPE_RAMP:
+      {
+        if (loop_status_[i] == LOOP_STATUS_SELF) {
+          return block.cv_slider[i];
+        }
+        const int range = seg_config & 0x0300;
+        if (range == 0x0200) {
+          // If in slow range, set slider min to 16 seconds and max to 1125 seconds
+          return block.cv_slider_alt(
+              i,
+              1.0f,
+              1.0f,
+              0.0f,
+              1.0f);
+        } else if (range == 0x0100) {
+          // If in fast range, constrain slider values to first 2/3 of the pot's travel
+          return block.cv_slider_alt(
+              i,
+              0.0f,
+              0.6667f,
+              0.0f,
+              1.0f);
+        } else {
+          // If in default range, retain slider range of 1 millisecond to 16 seconds
+          return block.cv_slider[i];
+        }
+      }
       case segment::TYPE_TURING:
+      {
         return block.cv_slider[i];
+      }
       default:
         {
           uint8_t scale = seg_config >> 12 & 0x03;

--- a/stages/ui.cc
+++ b/stages/ui.cc
@@ -321,8 +321,8 @@ void Ui::UpdateLEDs() {
       uint8_t fade_patterns[4] = {
         0xf,  // NONE
         FadePattern(4, 0, 0),  // START
-        FadePattern(4, 0x0f, 0),  // END = 15
-        FadePattern(4, 0x08, 0),  // SELF = 8
+        FadePattern(4, 0x0f, 0),  // END
+        FadePattern(4, 0x08, 0),  // SELF
       };
 
       uint8_t lfo_patterns[3] = {

--- a/stages/ui.cc
+++ b/stages/ui.cc
@@ -332,7 +332,7 @@ void Ui::UpdateLEDs() {
 
       uint8_t ramp_patterns[3] = {
         0xf,  // none
-        FadePattern(6, 0x08, true), // fast ramp
+        FadePattern(5, 0x08, true), // fast ramp
         FadePattern(7, 0x08, true), // slow ramp
       };
 

--- a/stages/ui.cc
+++ b/stages/ui.cc
@@ -375,7 +375,7 @@ void Ui::UpdateLEDs() {
         }
         if (settings_->state().color_blind == 1) {
           if (type == 0) {
-            uint8_t modulation = FadePattern(6, 13 - (2 * i), 0) >> 1;
+            uint8_t modulation = FadePattern(6, 13 - (2 * i), false) >> 1;
             brightness = brightness * (7 + modulation) >> 4;
           } else if (type == 1) {
             brightness = brightness >= 0x8 ? 0xf : 0;

--- a/stages/ui.cc
+++ b/stages/ui.cc
@@ -330,9 +330,10 @@ void Ui::UpdateLEDs() {
         FadePattern(2, 0x08, false), // fast
       };
 
-      uint8_t ramp_patterns[2] = {
+      uint8_t ramp_patterns[3] = {
+        0xf,  // none
+        FadePattern(6, 0x08, true), // fast ramp
         FadePattern(7, 0x08, true), // slow ramp
-        FadePattern(6, 0x08, true), // faster ramp
       };
 
       for (size_t i = 0; i < kNumChannels; ++i) {
@@ -347,17 +348,11 @@ void Ui::UpdateLEDs() {
         if (settings_->in_seg_gen_mode()) {
           if (chain_state_->loop_status(i) == ChainState::LOOP_STATUS_SELF) {
             brightness = lfo_patterns[configuration >> 8 & 0x3];
-          } else if (type != 0) {
-            brightness = fade_patterns[chain_state_->loop_status(i)];
-          } else if ((configuration & 0x0300) == 0x0200) {
-            brightness = chain_state_->loop_status(i) == ChainState::LOOP_STATUS_NONE ?
-              ramp_patterns[0] : fade_patterns[chain_state_->loop_status(i)] * 0.15f;
-          } else if ((configuration & 0x0300) == 0x0100) {
-            brightness = chain_state_->loop_status(i) == ChainState::LOOP_STATUS_NONE ?
-              ramp_patterns[1] : fade_patterns[chain_state_->loop_status(i)];
           } else {
-            brightness = chain_state_->loop_status(i) == ChainState::LOOP_STATUS_NONE ?
-              fade_patterns[0] : fade_patterns[chain_state_->loop_status(i)] * 0.4f;
+            brightness = fade_patterns[chain_state_->loop_status(i)];
+            if (type == 0) {
+              brightness = brightness * (ramp_patterns[configuration >> 8 & 0x3] + 1) >> 5;
+            }
           }
           if ((changing_slider_prop_ & (1 << i)) && (type == 1 || type == 2)) {
             uint8_t scale = 3 - ((configuration >> 12) & 0x3);

--- a/stages/ui.cc
+++ b/stages/ui.cc
@@ -133,6 +133,14 @@ void Ui::Poll() {
         if (settings_->in_seg_gen_mode()) {
           switch (seg_config[i] & 0x3) {
             case 0: // ramp
+              seg_config[i] &= ~0x0300; // reset range bits
+              if (slider < 0.25) {
+                seg_config[i] |= 0x0100;
+              } else if (slider > 0.75) {
+                seg_config[i] |= 0x0200;
+              }
+              // default middle range is 0, so no else
+              break;
             case 3: // random
               if (chain_state_->loop_status(i) == ChainState::LOOP_STATUS_SELF) {
                 seg_config[i] &= ~0x0300; // reset range bits

--- a/stages/ui.h
+++ b/stages/ui.h
@@ -82,7 +82,7 @@ class Ui {
   void MultiModeToggle(const uint8_t i);
 
   void UpdateLEDs();
-  uint8_t FadePattern(uint8_t shift, uint8_t phase) const;
+  uint8_t FadePattern(uint8_t shift, uint8_t phase, bool ramp) const;
 
   void show_mode() {
     for (size_t i = 0; i < kNumChannels; ++i) {


### PR DESCRIPTION
Adds extended and contracted frequency ranges on the Time/Level slider for non-looping green segments.

- Button+slider in the upper 25% region switches the slide pot's minimum value to 8V and its maximum value to "15.84V", so that without added CV this mode gives access to envelope stages ranging from 16 seconds to ~13.4 minutes.*
- Button+slider in the bottom 25% region switches the slide pot's minimum value to 0V and its maximum value to 5.3V, so that without subtracted CV this mode gives access to envelope stages ranging from 1 millisecond to ~2.2 seconds, with more pot precision for values in that range
- Button+slider in the middle gives Stages' default slider range (1 millisecond to 16 seconds)

*Allowing the slider to reach the full internal 16V range causes the segment to get stuck midway, but it can use 99% of that range without issues.

More on the slow range:
- With no external CV and the slider at maximum height, the segment duration is ~13.4 minutes
- With no external CV and the slider at 75% height, the segment duration is ~8.5 minutes
- With no external CV and the slider at 50% height, the segment duration is ~3 minutes
- With no external CV and the slider at 25% height, the segment duration is ~34 seconds
- With no external CV and the slider at minimum height, the segment duration is 16 seconds