### PR TITLE
Allow more extreme exponential curves in advanced mode

### DIFF
--- a/stages/segment_generator.cc
+++ b/stages/segment_generator.cc
@@ -134,7 +134,9 @@ inline float SegmentGenerator::WarpPhase(float t, float curve) const {
   if (flip) {
     t = 1.0f - t;
   }
-  const float a = 128.0f * curve * curve;
+  const float a = settings_->state().multimode != MULTI_MODE_STAGES_ADVANCED ? 128.0f * curve * curve
+    // In advanced segment generator mode, allow hyperexponential curves in the last quarter of the pot's turn
+    : 128.0f * curve * curve * max(1.0f, 10.0f * curve);
   t = (1.0f + a) * t / (1.0f + a * t);
   if (flip) {
     t = 1.0f - t;


### PR DESCRIPTION
This proposal affects only non-looping ramp segments.

In the standard segment generator mode, we get the same (as stock firmware) accelerating => linear => decelerating range of curves across the upper pot's travel.

In the advanced segment generator mode, this pot exhibits the same behavior for the first 50% of its turn but reaches the default exponential curve at around 2:30 o'clock and after that point bends into increasingly hyperexponential curves.  I find that this facilitates dialing in envelopes with decay tails that sound more "natural" in how they ring out, much like the response of a nice vactrol.  It should be particularly useful to people who only use linear VCAs and so need more control over their envelope's shape at its source.