### PR TITLE
Add unipolar mode for rise & fall slew

### DIFF
--- a/stages/segment_generator.cc
+++ b/stages/segment_generator.cc
@@ -302,7 +302,7 @@ void SegmentGenerator::ProcessRiseAndFall(
       ONE_POLE(lp_, value_, fall);
       phase_ = 1;
     }
-    out->value = lp_;
+    out->value = segments_[0].bipolar ? lp_ : fabsf(lp_);
     out->phase = phase_;
     out->segment = active_segment_ = fabsf(lp_) > 0.1 ? 0 : 1;
     out++;

--- a/stages/segment_generator.cc
+++ b/stages/segment_generator.cc
@@ -293,7 +293,7 @@ void SegmentGenerator::ProcessRiseAndFall(
   ParameterInterpolator primary(&primary_, local_parameters_[0].cv, size);
 
   while (size--) {
-    value_ = primary.Next();
+    value_ = segments_[0].bipolar ? primary.Next() : fabsf(primary.Next());
     if (value_ > lp_) {
       ONE_POLE(lp_, value_, rise);
       phase_ = 0;
@@ -301,7 +301,7 @@ void SegmentGenerator::ProcessRiseAndFall(
       ONE_POLE(lp_, value_, fall);
       phase_ = 1;
     }
-    out->value = segments_[0].bipolar ? lp_ : fabsf(lp_);
+    out->value = lp_;
     out->phase = phase_;
     out->segment = active_segment_ = fabsf(lp_) > 0.1 ? 0 : 1;
     out++;


### PR DESCRIPTION
Since polarity switching hasn't been doing anything for the rise & fall slew segment type, and since effective envelope following requires full-wave rectification of the signal, this proposes moving the existing behavior of the R&F slew into its bipolar mode and introducing to its unipolar mode output rectification that makes it more optimal for EF applications.  This way, you can still negatively track negative input voltages if you switch into the bipolar mode.

I've tried applying the fabsf at `value_ = primary.Next()` but this causes the segment to freeze its output at a high voltage when fed a bipolar square wave and when fall time is lower than 25% height.  (Switching to other segment types resets the output, but when returning to R&F slew, the output remains stuck somewhere near 8V.)  Also, if this is where the rectification happens, we still allow negative voltage on the output (depending on your rise & fall times) which is weird for a unipolar mode.

What I've found is that, if your slew limiter can output negative voltages (like this one can), the following patches produce the same behavior (that is optimal for tracking the amplitude of a varying-amplitude bipolar audio-rate signal, without getting ripples in your EF output):

(a) audio signal => full-wave rectifier => slew limiter
(b) audio signal => slew limiter => full-wave rectifier

And I've found that when fabsf is applied at the output when in unipolar (as proposed here), I get similar behavior to doing the (a) patch with a full-wave rectifier and a WMD/SSF Mini Slew.  I also can't get it to freeze up, nor to output 0V when rise & fall times are equal and a bipolar square wave is fed into Time.  (And obviously with this approach you don't get unexpected negative output from a unipolar mode.)

So I'd say the unipolar mode of R&F slew could be sold as an effective envelope follower, while the bipolar could be presented as a polarity-flexible R&F slew.