### PR TITLE
Debounce all state saves

### DIFF
--- a/stages/README.md
+++ b/stages/README.md
@@ -401,6 +401,14 @@ This way it is possible to modulate (and therefore sequence) the harmonics with 
 
 The frequency range in this mode can be controlled just as with the normal harmonic oscillator mode (hold leftmost button and move leftmost slider).
 
+Other changes
+-------------
+
+The original firmware would save state when a button was released.
+This firmware saves state 5 seconds after a state change occurs, reseting the the timer if another change occurs within that time.
+Because this firmware uses significantly more flash storage to save state, this change reduces the strain on flash in order to extend the life of the chip.
+All LEDs momentarily blink off when a save occurs.
+
 Known issues
 ------------
 

--- a/stages/chain_state.cc
+++ b/stages/chain_state.cc
@@ -661,7 +661,7 @@ void ChainState::HandleRequest(Settings* settings) {
   }
 
   if (dirty) {
-    settings->SaveState();
+    settings->SaveStateWithDebounce();
   }
 }
 

--- a/stages/envelope_mode.cc
+++ b/stages/envelope_mode.cc
@@ -53,9 +53,6 @@ namespace stages {
     // the channel is switched - see below). 
     active_channel_switch_time_ = 0;
 
-    // Disable save timer
-    save_timer_ = -1;
-
     // The index of the currently selected envelope. 
     active_envelope_ = 0;
 
@@ -175,7 +172,7 @@ namespace stages {
     }
     // Start/Reset the save timer if state was modified
     if (did_modify_state) {
-      save_timer_ = 0;
+      settings_->SaveStateWithDebounce();
     }
 
     // Process each channel
@@ -229,13 +226,6 @@ namespace stages {
       float value = envelope.Value();
       for (size_t i = 0; i < size; i++) {
         block->output[ch][i] = settings_->dac_code(ch, value);
-      }
-    }
-
-    if (save_timer_ >= 0) {
-      if (++save_timer_ >= kSaveTimeWait) {
-        save_timer_ = -1;
-        settings_->SaveState();
       }
     }
   }

--- a/stages/envelope_mode.h
+++ b/stages/envelope_mode.h
@@ -59,11 +59,6 @@ class EnvelopeMode {
   Settings* settings_;
   Ui* ui_;
 
-  // Keep track of whether latest values have yet to be saved.
-  // -1 means data is not dirty.
-  // a positive time (>=0) means data is dirty and is the number of ticks since it first became dirty.
-  int save_timer_;
-  
   // The index of the currently selected envelope
   size_t active_envelope_;
 

--- a/stages/settings.cc
+++ b/stages/settings.cc
@@ -90,8 +90,19 @@ void Settings::SavePersistentData() {
   chunk_storage_.SavePersistentData();
 }
 
-void Settings::SaveState() {
-  chunk_storage_.SaveState();
+void Settings::SaveStateWithDebounce() {
+  save_counter_ = kSaveDebounceMs;
+}
+
+bool Settings::PollSave() {
+  if (save_counter_ > 0) {
+    save_counter_--;
+    if (save_counter_ == 0) {
+      chunk_storage_.SaveState();
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace stages

--- a/stages/settings.h
+++ b/stages/settings.h
@@ -37,6 +37,8 @@
 
 namespace stages {
 
+const int kSaveDebounceMs = 5000;
+
 struct ChannelCalibrationData {
   float adc_offset;
   float adc_scale;
@@ -117,7 +119,11 @@ class Settings {
   bool Init();
 
   void SavePersistentData();
-  void SaveState();
+  // Schedules a state save after kSaveDebounceMs.
+  void SaveStateWithDebounce();
+  // Saves state if sufficient time has passed since the last change.
+  // Should be called exactly once per sys tick in the sys tick interrupt.
+  bool PollSave();
 
   inline ChannelCalibrationData* mutable_calibration_data(int channel) {
     return &persistent_data_.channel_calibration_data[channel];
@@ -154,6 +160,7 @@ class Settings {
  private:
   PersistentData persistent_data_;
   State state_;
+  int save_counter_ = 0;
 
   stmlib::ChunkStorage<
       0x08004000,

--- a/stages/ui.cc
+++ b/stages/ui.cc
@@ -82,7 +82,7 @@ void Ui::Init(Settings* settings, ChainState* chain_state, CvReader* cv_reader, 
     } else {
       state->color_blind = 1;
     }
-    settings_->SaveState();
+    settings_->SaveStateWithDebounce();
   }
 
   fill(&slider_led_counter_[0], &slider_led_counter_[kNumLEDs], 0);
@@ -127,7 +127,7 @@ void Ui::Poll() {
         uint16_t old_flags = seg_config[i];
 
         if (changing_slider_prop_ >> i & 1 // in the middle of change, so keep changing
-            || fabs(slider - locked_slider) > 0.05f) {
+            || fabsf(slider - locked_slider) > 0.05f) {
 
           changing_slider_prop_ |= 1 << i;
 
@@ -261,7 +261,7 @@ void Ui::Poll() {
   }
   if (!pressed && dirty_) {
     dirty_ = false;
-    settings_->SaveState();
+    settings_->SaveStateWithDebounce();
   }
 
   if (settings_->in_ouroboros_mode()) {
@@ -278,13 +278,13 @@ void Ui::Poll() {
         if (press_time_[i] > kLongPressDuration) { // Long-press
           if (press_time_[i] < kLongPressDurationForMultiModeToggle) { // But not long enough for multi-mode toggle
             s->segment_configuration[i] ^= 0b01000000; // Toggle waveshape MSB
-            settings_->SaveState();
+            settings_->SaveStateWithDebounce();
           }
         } else if (press_time_[i] > 0) {
           uint8_t type_bits = (s->segment_configuration[i] & 0b00110000) >> 4; // Get current waveshape LSB number
           s->segment_configuration[i] &= ~0b00110000; // Reset waveshape LSB bits
           s->segment_configuration[i] |= (((type_bits + 1) % 3) << 4); // Cycle through 0,1,2 and set LSB bits
-          settings_->SaveState();
+          settings_->SaveStateWithDebounce();
         }
         press_time_[i] = 0;
       }
@@ -310,6 +310,9 @@ void Ui::Poll() {
       }
     }
   }
+  if (settings_->PollSave()) {
+    save_blink_counter_ = kSaveBlinkMs;
+  }
 }
 
 void Ui::MultiModeToggle(const uint8_t i) {
@@ -322,7 +325,7 @@ void Ui::MultiModeToggle(const uint8_t i) {
     }
     chain_state_->SuspendSwitches(); // Don't consider chain button presses while changing mode
     state->multimode = (uint8_t) multimodes_[i];
-    settings_->SaveState();
+    settings_->SaveStateWithDebounce();
     chain_state_->start_reinit();
     eg_mode_->ReInit();
   }
@@ -350,7 +353,9 @@ void Ui::UpdateLEDs() {
   ChainState::ChainStateStatus status = chain_state_->status();
   const uint32_t ms = system_clock.milliseconds();
 
-  if (mode_ == UI_MODE_FACTORY_TEST) {
+  if (save_blink_counter_ > 0 ) {
+    save_blink_counter_--; // LEDs already cleared, so don't need to do anything
+  } else if (mode_ == UI_MODE_FACTORY_TEST) {
 
     size_t counter = (ms >> 8) % 3;
     for (size_t i = 0; i < kNumChannels; ++i) {

--- a/stages/ui.h
+++ b/stages/ui.h
@@ -43,6 +43,7 @@ const int32_t kLongPressDurationForMultiModeToggle = 5000;
 const int32_t kDiscreteStateBrightDur = 4000;
 const int32_t kDiscreteStateBlinkDur = 120;
 const uint32_t kDiscreteStatePreBlinkDur = 30;
+const int32_t kSaveBlinkMs = 120;
 
 namespace stages {
 
@@ -116,6 +117,8 @@ class Ui {
   uint8_t tracking_multimode_;
 
   uint32_t discrete_change_time_[kNumChannels];
+
+  int32_t save_blink_counter_ = 0;
 
   Settings* settings_;
   ChainState* chain_state_;


### PR DESCRIPTION
This ensures they don't happen too frequently when rapidly changing settings. It also allows main loop code to more easily and safely trigger saves by ensuring it will run in the sys tick interrupt.