### PR TITLE
Use slider leds to indicate channel status (independent envelope mode)

### DIFF
--- a/stages/envelope_mode.cc
+++ b/stages/envelope_mode.cc
@@ -188,9 +188,6 @@ namespace stages {
         slider_enabled_[ch] = true;
       }
 
-      // Set Slider LED to indicate whether slider is active for curent envelope.
-      ui_->set_slider_led(ch, slider_enabled_[ch], 1);
-
       // Check for gates. If the input is not patched, the previous channel's
       // gate status will be used.
       if (block->input_patched[ch]) {
@@ -221,7 +218,7 @@ namespace stages {
           ui_->set_led(ch, LED_COLOR_RED);
           break;
         default:
-          ui_->set_led(ch, ch == active_envelope_ ? LED_COLOR_YELLOW : LED_COLOR_OFF);
+          ui_->set_led(ch, LED_COLOR_OFF);
           break;
       }
 

--- a/stages/envelope_mode.h
+++ b/stages/envelope_mode.h
@@ -54,6 +54,14 @@ class EnvelopeMode {
 
   void ProcessEnvelopes(IOBuffer::Block* block, size_t size);
 
+  inline size_t get_active_envelope() {
+    return active_envelope_;
+  }
+
+  inline bool is_slider_enabled(size_t ch) {
+    return slider_enabled_[ch];
+  }
+
  private:
   EnvelopeManager envelope_manager_;
   Settings* settings_;


### PR DESCRIPTION
For the non-active channels, leds will be either on or off to indicate whether the slider is enabled (or not).

For the active channel, the led will pulse. It will pulse more frequently and for a longer duration if slider is enabled than if it is disabled.

This replaces the previous logic that showed which channel was active by marking the main led yellow (and only when the envelope wasn't active). This was both confusing (as yellow also indicated a specific envelope stage) and might never be shown if the envelope is retriggered prior to completing.

Ideally we would be performing a smoother fade, but the leds on the sliders seem to only support binary on/off.